### PR TITLE
feat(#33) : 카테고리 도메인 CRUD 프로젝트 검색기능 페이징으로 교체 및 QueryDsl 적용, 컨버터생성 및 적용

### DIFF
--- a/backend/src/main/java/com/example/readys7project/domain/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/example/readys7project/domain/category/controller/CategoryController.java
@@ -1,0 +1,69 @@
+package com.example.readys7project.domain.category.controller;
+
+import com.example.readys7project.domain.category.dto.CategoryDto;
+import com.example.readys7project.domain.category.dto.request.CategoryRequestDto;
+import com.example.readys7project.domain.category.service.CategoryService;
+import com.example.readys7project.global.dto.ApiResponseDto;
+import com.example.readys7project.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    // 카테고리 생성 (ADMIN 만 가능)
+    @PostMapping("/v1/categories")
+    public ResponseEntity<ApiResponseDto<CategoryDto>> createCategory(
+            @Valid@RequestBody CategoryRequestDto request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        String email = customUserDetails.getEmail();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponseDto.success(HttpStatus.CREATED,categoryService.createCategory(request, email)));
+    }
+
+    // 카테고리 전체 조회
+    @GetMapping("/v1/categories")
+    public ResponseEntity<ApiResponseDto<List<CategoryDto>>> getAllCategories() {
+        return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, categoryService.getAllCategories()));
+    }
+
+    // 카테고리 검색
+    @GetMapping("/v1/categories/search")
+    public ResponseEntity<ApiResponseDto<List<CategoryDto>>> searchCategories(
+            @RequestParam String name) {
+        return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, categoryService.searchCategories(name)));
+    }
+
+    // 카테고리 수정 (ADMIN 만 가능)
+    @PatchMapping("/v1/categories/{categoryId}")
+    public ResponseEntity<ApiResponseDto<CategoryDto>> updateCategory(
+            @PathVariable Long categoryId,
+            @Valid@RequestBody CategoryRequestDto request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        String email = customUserDetails.getEmail();
+        return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, categoryService.updateCategory(categoryId, request, email)));
+    }
+
+    // 카테고리 삭제 (ADMIN 만 가능)
+    @DeleteMapping("/v1/categories/{categoryId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteCategory(
+            @PathVariable Long categoryId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        String email = customUserDetails.getEmail();
+        categoryService.deleteCategory(categoryId, email);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponseDto.successWithNoContent());
+    }
+}

--- a/backend/src/main/java/com/example/readys7project/domain/category/dto/CategoryDto.java
+++ b/backend/src/main/java/com/example/readys7project/domain/category/dto/CategoryDto.java
@@ -1,0 +1,12 @@
+package com.example.readys7project.domain.category.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CategoryDto(
+        Long id,
+        String name,
+        String icon,
+        String description,
+        Integer displayOrder
+) {}

--- a/backend/src/main/java/com/example/readys7project/domain/category/dto/request/CategoryRequestDto.java
+++ b/backend/src/main/java/com/example/readys7project/domain/category/dto/request/CategoryRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.readys7project.domain.category.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record CategoryRequestDto(
+
+        @NotBlank(message = "카테고리는 필수입니다.")
+        String name,
+
+        String icon,
+
+        String description,
+
+        @NotNull(message = "정렬 순서는 필수입니다.")
+        Integer displayOrder
+) { }

--- a/backend/src/main/java/com/example/readys7project/domain/category/entity/Category.java
+++ b/backend/src/main/java/com/example/readys7project/domain/category/entity/Category.java
@@ -24,17 +24,31 @@ public class Category extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name;
 
+    @Column(name = "icon")
     private String icon;
 
+    @Column(name = "description")
     private String description;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "display_order")
     private Integer displayOrder; // DB 정렬을 위한 컬럼
 
     private boolean isDeleted = false;
 
     @Builder
     public Category(String name, String icon, String description, Integer displayOrder) {
+        this.name = name;
+        this.icon = icon;
+        this.description = description;
+        this.displayOrder = displayOrder;
+    }
+
+    public void update(
+            String name,
+            String icon,
+            String description,
+            Integer displayOrder
+    ) {
         this.name = name;
         this.icon = icon;
         this.description = description;

--- a/backend/src/main/java/com/example/readys7project/domain/category/entity/Category.java
+++ b/backend/src/main/java/com/example/readys7project/domain/category/entity/Category.java
@@ -43,7 +43,7 @@ public class Category extends BaseEntity {
         this.displayOrder = displayOrder;
     }
 
-    public void update(
+    public void updateCategory(
             String name,
             String icon,
             String description,

--- a/backend/src/main/java/com/example/readys7project/domain/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/example/readys7project/domain/category/repository/CategoryRepository.java
@@ -3,5 +3,13 @@ package com.example.readys7project.domain.category.repository;
 import com.example.readys7project.domain.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    // 카테고리 이름 중복 체크용
+    boolean existsByName(String name);
+
+    // 카테고리 이름 기준 LIKE 검색용
+    List<Category> findByNameContaining(String name);
 }

--- a/backend/src/main/java/com/example/readys7project/domain/category/service/CategoryService.java
+++ b/backend/src/main/java/com/example/readys7project/domain/category/service/CategoryService.java
@@ -137,7 +137,7 @@ public class CategoryService {
 
         // 5. 카테고리 정보 업데이트
         // Dirty Checking에 의해 트랜잭션 종료 시 자동으로 UPDATE 쿼리가 실행됨
-        category.update(
+        category.updateCategory(
                 request.name(),
                 request.icon(),
                 request.description(),

--- a/backend/src/main/java/com/example/readys7project/domain/category/service/CategoryService.java
+++ b/backend/src/main/java/com/example/readys7project/domain/category/service/CategoryService.java
@@ -1,0 +1,195 @@
+package com.example.readys7project.domain.category.service;
+
+import com.example.readys7project.domain.category.dto.CategoryDto;
+import com.example.readys7project.domain.category.dto.request.CategoryRequestDto;
+import com.example.readys7project.domain.category.entity.Category;
+import com.example.readys7project.domain.category.repository.CategoryRepository;
+import com.example.readys7project.domain.user.admin.entity.Admin;
+import com.example.readys7project.domain.user.admin.enums.AdminStatus;
+import com.example.readys7project.domain.user.admin.repository.AdminRepository;
+import com.example.readys7project.domain.user.auth.entity.User;
+import com.example.readys7project.domain.user.auth.enums.UserRole;
+import com.example.readys7project.domain.user.auth.repository.UserRepository;
+import com.example.readys7project.global.exception.common.ErrorCode;
+import com.example.readys7project.global.exception.domain.CategoryException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
+
+    /**
+     * 카테고리 생성 (ADMIN 전용)
+     * - ADMIN 역할을 가진 사용자만 카테고리 생성 가능
+     * - 카테고리 이름 중복을 허용하지 않음
+     */
+    @Transactional
+    public CategoryDto createCategory(CategoryRequestDto request, String userEmail) {
+
+        // 1. 요청한 사용자 존재 여부 검증
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CategoryException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. ADMIN 역할 여부 검증(CLIENT, DEVELOPER는 카테고리 생성 불가)
+        if (user.getUserRole() != UserRole.ADMIN) {
+            throw new CategoryException(ErrorCode.USER_FORBIDDEN);
+        }
+
+        // 3. Admin 테이블에서 APPROVED 상태인지 확인
+        Admin admin = adminRepository.findByUser(user)
+                .orElseThrow(() -> new CategoryException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (admin.getStatus() != AdminStatus.APPROVED) {
+            throw new CategoryException(ErrorCode.ADMIN_NOT_APPROVED);
+        }
+
+        // 4. 카테고리 이름 중복 검증
+        if (categoryRepository.existsByName(request.name())) {
+            throw new CategoryException(ErrorCode.CATEGORY_ALREADY_EXISTS);
+        }
+
+        // 5. 카테고리 이름 중복 검증
+        Category category = Category.builder()
+                .name(request.name())
+                .icon(request.icon())
+                .description(request.description())
+                .displayOrder(request.displayOrder())
+                .build();
+
+        // 6. 저장 후 DTO로 변환하여 반환
+        return convertToDto(categoryRepository.save(category));
+    }
+
+    /**
+     * 카테고리 전체 조회
+     * - 인증 없이 누구나 조회 가능
+     * - displayOrder 기준으로 정렬된 목록을 반환
+     */
+    @Transactional(readOnly = true)
+    public List<CategoryDto> getAllCategories() {
+
+        // displayOrder 기준 오름차순 정렬하여 전체 조회 후 DTO 변환하여 반환
+        return categoryRepository.findAll().stream()
+                .sorted((a,b) -> a.getDisplayOrder().compareTo(b.getDisplayOrder()))
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 카테고리 검색
+     * - 카테고리 이름을 기준으로 LIKE 검색
+     * - 인증 없이 누구나 검색 가능
+     */
+    @Transactional(readOnly = true)
+    public List<CategoryDto> searchCategories(String name) {
+
+        // 이름 기준 LIKE 검색 후 DTO 변환하여 반환
+        return categoryRepository.findByNameContaining(name).stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 카테고리 수정 (ADMIN 전용)
+     * - ADMIN 역할을 가진 사용자만 카테고리 수정 가능
+     * - 수정하려는 이름이 다른 카테고리와 중복되면 예외 발생
+     * - @Transactional 덕분에 별도 save() 호출 없이 변경사항이 자동 반영 (Dirty Checking)
+     */
+    @Transactional
+    public CategoryDto updateCategory(Long categoryId, CategoryRequestDto request, String userEmail) {
+
+        // 1. 요청한 사용자 존재 여부 검증
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CategoryException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. ADMIN 역할 여부 검증
+        if (user.getUserRole() != UserRole.ADMIN) {
+            throw new CategoryException(ErrorCode.USER_FORBIDDEN);
+        }
+
+        // 2단계: Admin 테이블에서 APPROVED 상태인지 확인
+        Admin admin = adminRepository.findByUser(user)
+                .orElseThrow(() -> new CategoryException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (admin.getStatus() != AdminStatus.APPROVED) {
+            throw new CategoryException(ErrorCode.ADMIN_NOT_APPROVED);
+        }
+
+        // 3. 수정할 카테고리 존재 여부 검증
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CategoryException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        // 4. 변경하려는 이름이 다른 카테고리와 중복되는지 검증
+        // 현재 카테고리 이름과 동일한 경우는 중복으로 처리하지 않음
+        if (!category.getName().equals(request.name())
+                 && categoryRepository.existsByName(request.name())) {
+            throw new CategoryException(ErrorCode.CATEGORY_ALREADY_EXISTS);
+        }
+
+        // 5. 카테고리 정보 업데이트
+        // Dirty Checking에 의해 트랜잭션 종료 시 자동으로 UPDATE 쿼리가 실행됨
+        category.update(
+                request.name(),
+                request.icon(),
+                request.description(),
+                request.displayOrder()
+        );
+
+        // 6. 수정된 카테고리를 DTO로 변환하여 반환
+        return convertToDto(category);
+    }
+
+    /**
+     * 카테고리 삭제 (ADMIN 전용)
+     * - ADMIN 역할을 가진 사용자만 카테고리 삭제 가능
+     */
+    @Transactional
+    public void deleteCategory(Long categoryId, String userEmail) {
+
+        // 1. 요청한 사용자 존재 여부 검증
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new CategoryException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. ADMIN 역할 여부 검증
+        if (user.getUserRole() != UserRole.ADMIN) {
+            throw new CategoryException(ErrorCode.USER_FORBIDDEN);
+        }
+
+        Admin admin = adminRepository.findByUser(user)
+                .orElseThrow(() -> new CategoryException(ErrorCode.ADMIN_NOT_FOUND));
+
+        if (admin.getStatus() != AdminStatus.APPROVED) {
+            throw new CategoryException(ErrorCode.ADMIN_NOT_APPROVED);
+        }
+
+        // 3. 삭제할 카테고리 존재 여부 검증
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CategoryException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        // 4. 카테고리 삭제
+        categoryRepository.delete(category);
+    }
+
+    /**
+     * 카테고리 엔티티 -> CategoryDto 변환
+     * - Entity가 Controller 밖으로 노출되지 않도록 DTO로 반환
+     */
+    private CategoryDto convertToDto(Category category) {
+        return CategoryDto.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .icon(category.getIcon())
+                .description(category.getDescription())
+                .displayOrder(category.getDisplayOrder())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/readys7project/domain/portfolio/dto/PortfolioDto.java
+++ b/backend/src/main/java/com/example/readys7project/domain/portfolio/dto/PortfolioDto.java
@@ -5,17 +5,18 @@ import lombok.Builder;
 
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record PortfolioDto (
 
-     Long id,
-    Long developerId,
-     String title,
-    String description,
-    String imageUrl,
-    String projectUrl,
-     String skills,
-    LocalDateTime createdAt,
-    LocalDateTime updatedAt
+        Long id,
+        Long developerId,
+        String title,
+        String description,
+        String imageUrl,
+        String projectUrl,
+        List<String> skills,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ){}

--- a/backend/src/main/java/com/example/readys7project/domain/portfolio/dto/request/PortfolioRequestDto.java
+++ b/backend/src/main/java/com/example/readys7project/domain/portfolio/dto/request/PortfolioRequestDto.java
@@ -3,6 +3,8 @@ package com.example.readys7project.domain.portfolio.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
+import java.util.List;
+
 
 @Builder
 public record
@@ -15,6 +17,6 @@ PortfolioRequestDto(
 
         String imageUrl,
         String projectUrl,
-        String skills
+        List<String> skills
 )
 { }

--- a/backend/src/main/java/com/example/readys7project/domain/portfolio/entity/Portfolio.java
+++ b/backend/src/main/java/com/example/readys7project/domain/portfolio/entity/Portfolio.java
@@ -2,6 +2,7 @@ package com.example.readys7project.domain.portfolio.entity;
 
 
 import com.example.readys7project.domain.user.developer.entity.Developer;
+import com.example.readys7project.global.converter.StringListConverter;
 import com.example.readys7project.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -12,6 +13,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.util.List;
 
 
 @Entity
@@ -42,9 +45,9 @@ public class Portfolio extends BaseEntity {
     @Column(name = "project_url", length = 2083)
     private String projectUrl;
 
-
+    @Convert(converter = StringListConverter.class)
     @Column(name = "skills", columnDefinition = "json")
-    private String skills;
+    private List<String> skills;
 
 
     private boolean isDeleted = false;

--- a/backend/src/main/java/com/example/readys7project/domain/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/controller/ProjectController.java
@@ -1,5 +1,6 @@
 package com.example.readys7project.domain.project.controller;
 
+import com.example.readys7project.domain.category.entity.Category;
 import com.example.readys7project.domain.project.dto.ProjectDto;
 import com.example.readys7project.domain.project.dto.request.ProjectRequestDto;
 import com.example.readys7project.domain.project.service.ProjectService;
@@ -7,6 +8,8 @@ import com.example.readys7project.global.dto.ApiResponseDto;
 import com.example.readys7project.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -45,23 +48,12 @@ public class ProjectController {
 
     // 프로젝트 검색
     @GetMapping("/v1/projects/search")
-    public ResponseEntity<ApiResponseDto<List<ProjectDto>>> searchProjects(
-            @RequestParam(required = false) String category,
+    public ResponseEntity<ApiResponseDto<Page<ProjectDto>>> searchProjects(
+            @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) String status,
-            @RequestParam(required = false) String skill) {
-        return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, projectService.searchProjects(category, status, skill)));
-    }
-
-    // 내가 등록한 프로젝트 조회
-    @GetMapping("/v1/projects/my-projects")
-    public ResponseEntity<ApiResponseDto<List<ProjectDto>>> getMyProjects(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
-    ) {
-        String email = customUserDetails.getEmail();
-
-        return ResponseEntity.ok(
-                ApiResponseDto.success(HttpStatus.OK,
-                        projectService.getMyProjects(email)));
+            @RequestParam(required = false) List<String> skill,
+            Pageable pageable) {
+        return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, projectService.searchProjects(categoryId, status, skill, pageable)));
     }
 
     // 프로젝트 수정 (본인 Client만 가능)

--- a/backend/src/main/java/com/example/readys7project/domain/project/dto/ProjectDto.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/dto/ProjectDto.java
@@ -14,7 +14,7 @@ public record ProjectDto(
     Integer minBudget,
     Integer maxBudget,
     Integer duration,
-    String skills,
+    List<String> skills,
     String status,
     Integer currentProposalCount,
     Integer maxProposalCount,

--- a/backend/src/main/java/com/example/readys7project/domain/project/dto/request/ProjectRequestDto.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/dto/request/ProjectRequestDto.java
@@ -28,7 +28,7 @@ public record ProjectRequestDto(
     @NotNull(message = "기간은 필수입니다.")
     Integer duration,
 
-    String skills,
+    List<String> skills,
 
     @NotNull(message = "최대 지원자 수는 필수입니다.")
     Integer maxProposalCount

--- a/backend/src/main/java/com/example/readys7project/domain/project/entity/Project.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/entity/Project.java
@@ -88,7 +88,7 @@ public class Project extends BaseEntity {
 
     }
 
-    public void update(
+    public void updateProject(
             String title,
             String description,
             Category category,

--- a/backend/src/main/java/com/example/readys7project/domain/project/entity/Project.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/entity/Project.java
@@ -3,6 +3,7 @@ package com.example.readys7project.domain.project.entity;
 import com.example.readys7project.domain.category.entity.Category;
 import com.example.readys7project.domain.project.enums.ProjectStatus;
 import com.example.readys7project.domain.user.client.entity.Client;
+import com.example.readys7project.global.converter.StringListConverter;
 import com.example.readys7project.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -12,6 +13,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.List;
 
 
 @Entity
@@ -31,41 +34,43 @@ public class Project extends BaseEntity {
     @JoinColumn(name = "client_id", nullable = false)
     private Client client;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "title")
     private String title;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false, name = "description")
     private String description;
 
-    @Column(columnDefinition = "json")
-    private String skills;
+    @Convert(converter = StringListConverter.class)
+    @Column(columnDefinition = "json", name = "skills")
+    private List<String> skills;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category; // web, mobile, ai, blockchain, game, design
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "min_budget")
     private Integer minBudget; // 최저예산, String 타입으로 받을시 검색/필터링/정렬 전부 불가능 // 단위: 만원 or 원
-    @Column(nullable = false)
+    @Column(nullable = false, name = "max_budget")
     private Integer maxBudget; // 최대예산
 
-    @Column(nullable = false) // 그래서 String에서 Integer 타입으로 변경
+    @Column(nullable = false, name = "duration") // 그래서 String에서 Integer 타입으로 변경
     private Integer duration; // 마찬가지
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, name = "project_status")
     private ProjectStatus status;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "current_proposal_count")
     private Integer currentProposalCount; // 현재 제안서 수
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "max_proposal_count")
     private Integer maxProposalCount;     // 최대 제안서 수
 
     private boolean isDeleted = false;
 
     @Builder
-    public Project(Client client, String title, String description, String skills, Category category,
+    public Project(Client client, String title, String description, List<String> skills, Category category,
                    Integer minBudget,Integer maxBudget, Integer duration, Integer maxProposalCount) {
         this.client = client;
         this.title = title;
@@ -87,7 +92,7 @@ public class Project extends BaseEntity {
             String title,
             String description,
             Category category,
-            String skills,
+            List<String> skills,
             Integer minBudget,
             Integer maxBudget,
             Integer duration,

--- a/backend/src/main/java/com/example/readys7project/domain/project/repository/ProjectQueryRepository.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/repository/ProjectQueryRepository.java
@@ -1,0 +1,24 @@
+package com.example.readys7project.domain.project.repository;
+
+import com.example.readys7project.domain.category.entity.Category;
+import com.example.readys7project.domain.project.entity.Project;
+import com.example.readys7project.domain.project.enums.ProjectStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ProjectQueryRepository {
+
+    /**
+     * 프로젝트 검색 (QueryDSL 동적 쿼리)
+     * - category, status, skills 조건으로 필터링
+     * - 각 조건은 null 또는 empty일 경우 무시 (동적 쿼리)
+     */
+    Page<Project> searchProjects(
+            Category category,
+            ProjectStatus status,
+            List<String> skills,
+            Pageable pageable
+    );
+}

--- a/backend/src/main/java/com/example/readys7project/domain/project/repository/ProjectQueryRepositoryImpl.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/repository/ProjectQueryRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.example.readys7project.domain.project.repository;
+
+import com.example.readys7project.domain.category.entity.Category;
+import com.example.readys7project.domain.project.entity.Project;
+import com.example.readys7project.domain.project.entity.QProject;
+import com.example.readys7project.domain.project.enums.ProjectStatus;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectQueryRepositoryImpl implements ProjectQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Project> searchProjects(
+            Category category,
+            ProjectStatus status,
+            List<String> skills,
+            Pageable pageable
+    ) {
+        QProject qProject = QProject.project;
+
+        // 동적 조건 빌더 - 각 조건이 null이면 자동으로 무시됨
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 카테고리 조건 (null이면 전체 조회)
+        if (category != null) {
+            builder.and(qProject.category.eq(category));
+        }
+
+        // 상태 조건 (null이면 전체 조회)
+        if (status != null) {
+            builder.and(qProject.status.eq(status));
+        }
+
+        // 스킬 조건 - OR 조건 (skills 중 하나라도 JSON 문자열에 포함되면 조회)
+        // skills 필드가 JSON 문자열이므로 LIKE로 각 스킬을 검색
+        if (skills != null && !skills.isEmpty()) {
+            BooleanBuilder skillBuilder = new BooleanBuilder();
+            for (String skill : skills) {
+                // JSON 문자열 안에 해당 스킬이 포함되어 있는지 LIKE 검색
+                // 예: skills = ["Java", "Python"] 에서 "Java" 검색 시
+                // LIKE '%Java%' 로 검색
+                skillBuilder.or(qProject.skills.contains(skill));
+            }
+            builder.and(skillBuilder);
+        }
+
+        // 실제 데이터 조회 쿼리
+        List<Project> content = jpaQueryFactory
+                .selectFrom(qProject)
+                .where(builder)
+                .offset(pageable.getOffset())       // 페이지 시작점
+                .limit(pageable.getPageSize())      // 페이지 크기
+                .orderBy(qProject.createdAt.desc()) // 최신순 정렬
+                .fetch();
+
+        // 전체 카운트 쿼리 (페이징 메타데이터용)
+        // count 쿼리는 별도로 분리하여 불필요한 JOIN 방지
+        Long total = jpaQueryFactory
+                .select(qProject.count())
+                .from(qProject)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0);
+    }
+}

--- a/backend/src/main/java/com/example/readys7project/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/repository/ProjectRepository.java
@@ -1,5 +1,6 @@
 package com.example.readys7project.domain.project.repository;
 
+import com.example.readys7project.domain.category.entity.Category;
 import com.example.readys7project.domain.project.entity.Project;
 import com.example.readys7project.domain.project.enums.ProjectStatus;
 import org.springframework.data.domain.Page;
@@ -14,19 +15,8 @@ import java.util.List;
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByClientId(Long clientId);
-    List<Project> findByCategory(String category);
+    List<Project> findByCategory(Category category);
     List<Project> findByStatus(ProjectStatus status);
-
     // 내 프로젝트 목록 조회 페이징
     Page<Project> findByClientId(Long clientId, Pageable pageable);
-
-    @Query("SELECT p FROM Project p WHERE " +
-           "(:category IS NULL OR p.category = :category) AND " +
-           "(:status IS NULL OR p.status = :status) AND " +
-           "(:skill IS NULL OR :skill MEMBER OF p.skills)")
-    List<Project> searchProjects(
-        @Param("category") String category,
-        @Param("status") ProjectStatus status,
-        @Param("skill") String skill
-    );
 }

--- a/backend/src/main/java/com/example/readys7project/domain/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/repository/ProjectRepository.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, ProjectQueryRepository {
     List<Project> findByClientId(Long clientId);
     List<Project> findByCategory(Category category);
     List<Project> findByStatus(ProjectStatus status);

--- a/backend/src/main/java/com/example/readys7project/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/service/ProjectService.java
@@ -161,7 +161,7 @@ public class ProjectService {
 
         // 6. 프로젝트 정보 업데이트
         // Dirty Checking에 의해 트랜잭션 종료 시 자동으로 UPDATE 쿼리가 실행됨
-        project.update(
+        project.updateProject(
                 request.title(),
                 request.description(),
                 category,

--- a/backend/src/main/java/com/example/readys7project/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/service/ProjectService.java
@@ -6,6 +6,7 @@ import com.example.readys7project.domain.project.dto.ProjectDto;
 import com.example.readys7project.domain.project.dto.request.ProjectRequestDto;
 import com.example.readys7project.domain.project.entity.Project;
 import com.example.readys7project.domain.project.enums.ProjectStatus;
+import com.example.readys7project.domain.project.repository.ProjectQueryRepositoryImpl;
 import com.example.readys7project.domain.project.repository.ProjectRepository;
 import com.example.readys7project.domain.user.auth.entity.User;
 import com.example.readys7project.domain.user.auth.enums.UserRole;
@@ -15,6 +16,8 @@ import com.example.readys7project.domain.user.client.repository.ClientRepository
 import com.example.readys7project.global.exception.common.ErrorCode;
 import com.example.readys7project.global.exception.domain.ProjectException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +32,7 @@ public class ProjectService {
     private final UserRepository userRepository;
     private final ClientRepository clientRepository;
     private final CategoryRepository categoryRepository;
+    private final ProjectQueryRepositoryImpl projectQueryRepositoryImpl;
 
     /**
      * 프로젝트 생성 (CLIENT 역할을 가진 사용자만 가능)
@@ -101,45 +105,27 @@ public class ProjectService {
     }
 
     /**
-     * 프로젝느 검색
+     * 프로젝트 검색
      * - category, status, skill 조건으로 필터링
      * - 각 조건은 null일 경우 무시 (동적 쿼리)
      * - 인증 없이 누구나 조회 가능
      */
     @Transactional(readOnly = true)
-    public List<ProjectDto> searchProjects(String category, String status, String skill) {
+    public Page<ProjectDto> searchProjects(Long categoryId, String status, List<String> skill, Pageable pageable) {
 
-        // 1. status 문자열을 Enum으로 변환 (null이면 전체 조회)
+        // 1. category 조회 (null이면 전체 조회)
+        Category category = categoryId != null
+                ? categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new ProjectException(ErrorCode.CATEGORY_NOT_FOUND))
+                : null;
+
+        // 2. status 문자열을 Enum으로 변환 (null이면 전체 조회)
         ProjectStatus projectStatus = status != null ?
             ProjectStatus.valueOf(status.toUpperCase()) : null;
 
-        // 2. 조건에 맞는 프로젝트 목록 조회 후 DTO 변환하여 반환
-        return projectRepository.searchProjects(category, projectStatus, skill).stream()
-                .map(this::convertToDto)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * 내가 등록한 프로젝트 목록 조회 (CLIENT 전용)
-     * - 로그인한 사용자가 등록한 프로젝트만 조회
-     * - CLIENT 역할이 아닌 경우 차단
-     */
-    @Transactional(readOnly = true)
-    public List<ProjectDto> getMyProjects(String userEmail) {
-
-        // 1. 요청한 사용자 존재 여부 검증
-        User user = userRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new ProjectException(ErrorCode.USER_NOT_FOUND));
-
-        // 2. 요청한 사용자의 Client 역할 검증
-        Client client = clientRepository.findByUser(user)
-                .orElseThrow(() -> new ProjectException(ErrorCode.USER_NOT_FOUND));
-
-
-        // 3. 해당 Client가 등록한 프로젝트 목록 조회 후 DTO 변환하여 반환
-        return projectRepository.findByClientId(client.getId()).stream()
-                .map(this::convertToDto)
-                .toList();
+        // 3. 조건에 맞는 프로젝트 목록 조회 후 DTO 변환하여 반환
+        return projectQueryRepositoryImpl.searchProjects(category, projectStatus, skill, pageable)
+                .map(this::convertToDto);
     }
 
     /**

--- a/backend/src/main/java/com/example/readys7project/domain/project/service/ProjectService.java
+++ b/backend/src/main/java/com/example/readys7project/domain/project/service/ProjectService.java
@@ -32,7 +32,6 @@ public class ProjectService {
     private final UserRepository userRepository;
     private final ClientRepository clientRepository;
     private final CategoryRepository categoryRepository;
-    private final ProjectQueryRepositoryImpl projectQueryRepositoryImpl;
 
     /**
      * 프로젝트 생성 (CLIENT 역할을 가진 사용자만 가능)
@@ -124,7 +123,7 @@ public class ProjectService {
             ProjectStatus.valueOf(status.toUpperCase()) : null;
 
         // 3. 조건에 맞는 프로젝트 목록 조회 후 DTO 변환하여 반환
-        return projectQueryRepositoryImpl.searchProjects(category, projectStatus, skill, pageable)
+        return projectRepository.searchProjects(category, projectStatus, skill, pageable)
                 .map(this::convertToDto);
     }
 

--- a/backend/src/main/java/com/example/readys7project/domain/user/client/controller/ClientController.java
+++ b/backend/src/main/java/com/example/readys7project/domain/user/client/controller/ClientController.java
@@ -61,7 +61,7 @@ public class ClientController {
     }
 
     // 내 프로젝트 목록 조회
-    @GetMapping("/v1/clients/my-project")
+    @GetMapping("/v1/clients/my-projects")
     public ResponseEntity<ApiResponseDto<GetClientProjectsListResponseDto>> getMyProjects(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam(defaultValue = "1") int page,

--- a/backend/src/main/java/com/example/readys7project/domain/user/developer/dto/DeveloperDto.java
+++ b/backend/src/main/java/com/example/readys7project/domain/user/developer/dto/DeveloperDto.java
@@ -3,6 +3,8 @@ package com.example.readys7project.domain.user.developer.dto;
 import com.example.readys7project.domain.user.enums.ParticipateType;
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
 public record DeveloperDto(
         Long id,
@@ -11,7 +13,7 @@ public record DeveloperDto(
         Double rating,
         Integer reviewCount,
         Integer completedProjects,
-        String skills,          // JSON 문자열
+        List<String> skills,          // JSON 문자열
         Integer minHourlyPay,
         Integer maxHourlyPay,
         String responseTime,

--- a/backend/src/main/java/com/example/readys7project/domain/user/developer/dto/request/DeveloperProfileRequestDto.java
+++ b/backend/src/main/java/com/example/readys7project/domain/user/developer/dto/request/DeveloperProfileRequestDto.java
@@ -5,13 +5,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+import java.util.List;
+
 @ValidHourlyPayRange   // 커스텀 어노테이션
 public record DeveloperProfileRequestDto (
 
         @NotBlank(message = "직함은 필수입니다")
         String title,
 
-        String skills,        // JSON 문자열 ex: ["React", "Spring"]
+        List<String> skills,        // JSON 문자열 ex: ["React", "Spring"]
 
         @NotNull(message = "최소 시급은 필수입니다")
         @Positive(message = "최소 시급은 0보다 커야합니다")  // @Positive -> 양수만 허용

--- a/backend/src/main/java/com/example/readys7project/domain/user/developer/entity/Developer.java
+++ b/backend/src/main/java/com/example/readys7project/domain/user/developer/entity/Developer.java
@@ -2,11 +2,14 @@ package com.example.readys7project.domain.user.developer.entity;
 
 import com.example.readys7project.domain.user.auth.entity.User;
 import com.example.readys7project.domain.user.enums.ParticipateType;
+import com.example.readys7project.global.converter.StringListConverter;
 import com.example.readys7project.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.util.List;
 
 
 @Getter
@@ -43,8 +46,9 @@ public class Developer extends BaseEntity {
     @Column(name = "max_hourly_pay")
     private Integer maxHourlyPay;   // 시간당 요금
 
+    @Convert(converter = StringListConverter.class)
     @Column(columnDefinition = "json")
-    private String skills;   // 개발자 보유 스킬
+    private List<String> skills;   // 개발자 보유 스킬
 
     @Column(name = "response_time")
     private String responseTime;   // 응답 시간 (예: "1시간 이내")

--- a/backend/src/main/java/com/example/readys7project/global/converter/StringListConverter.java
+++ b/backend/src/main/java/com/example/readys7project/global/converter/StringListConverter.java
@@ -1,0 +1,47 @@
+package com.example.readys7project.global.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * List<String> → JSON 문자열 변환 (DB 저장 시)
+     * 예: ["Java", "Python"] → "[\"Java\",\"Python\"]"
+     */
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "[]";
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("skills 직렬화 실패", e);
+        }
+    }
+
+    /**
+     * JSON 문자열 → List<String> 변환 (DB 조회 시)
+     * 예: "[\"Java\",\"Python\"]" → ["Java", "Python"]
+     */
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<List<String>>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("skills 역직렬화 실패", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/example/readys7project/global/exception/common/ErrorCode.java
+++ b/backend/src/main/java/com/example/readys7project/global/exception/common/ErrorCode.java
@@ -24,8 +24,10 @@ public enum ErrorCode {
     // Project
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
     PROJECT_ALREADY_CLOSED(HttpStatus.BAD_REQUEST,"이미 마감된 프로젝트입니다."),
+
     // Category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"카테고리를 찾을 수 없습니다."),
+    CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT,"이미 존재하는 카테고리입니다."),
 
     // Proposal
     PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "제안서를 찾을 수 없습니다."),
@@ -38,6 +40,7 @@ public enum ErrorCode {
     ADMIN_STATUS_NOT_MATCH(HttpStatus.BAD_REQUEST, "승인 대기중 상태가 아닙니다."),
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자를 찾을 수 없습니다"),
     ADMIN_ALREADY_APPROVE(HttpStatus.BAD_REQUEST, "이미 승인된 관리자 입니다."),
+    ADMIN_NOT_APPROVED(HttpStatus.FORBIDDEN, "승인되지 않은 관리자입니다."),
 
     // Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),


### PR DESCRIPTION
## 개요
- 카테고리 도메인 CRUD 프로젝트 검색기능 페이징으로 교체 및 QueryDsl 적용, 컨버터생성 및 적용

## 변경 사항
- 카테고리 도메인 CRUD 
- 프로젝트 검색기능 페이징으로 교체 및 QueryDsl 적용 
- 컨버터생성 및 적용
## 관련 이슈
- 이 PR과 관련된 이슈 번호를 작성해주세요. (e.g., `#123`)
  - Resolves #33 
