### PR TITLE
refactor(#108): 채팅방 구독 검증 추가, 제안서 제출 시 멱등성, 채팅 unreadcount에서 DB-Redis 간 데이터 불일치

### DIFF
--- a/backend/src/main/java/com/example/readys7project/config/AsyncConfig.java
+++ b/backend/src/main/java/com/example/readys7project/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.example.readys7project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("Async-Executor-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/example/readys7project/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/readys7project/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.readys7project.config;
 import com.example.readys7project.global.security.CustomUserDetailsService;
 import com.example.readys7project.global.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -32,6 +33,9 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -56,13 +60,13 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/v1/projects/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/v1/categories/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/v1/developers/**").permitAll()
-                    .requestMatchers(HttpMethod.GET, "v1/skills/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/v1/skills/**").permitAll()
                     
                     // 관리자 전용 경로 설정 추가
                     .requestMatchers("/v1/admin/**").hasRole("ADMIN")
                     
                     .requestMatchers("/v1/developers/profile").authenticated()
-                    .requestMatchers("/v1/developers/my-projects").authenticated()
+                    .requestMatchers("/v1/developers/me/my-projects").authenticated()
                     .requestMatchers("/ws/**").permitAll()
                     .anyRequest().authenticated()
             )
@@ -77,7 +81,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedOrigins(allowedOrigins);
         config.setAllowedMethods(List.of("*"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/backend/src/main/java/com/example/readys7project/domain/chat/message/event/MessageCreatedEvent.java
+++ b/backend/src/main/java/com/example/readys7project/domain/chat/message/event/MessageCreatedEvent.java
@@ -1,0 +1,15 @@
+package com.example.readys7project.domain.chat.message.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 메시지 생성 시 발생하는 이벤트
+ * DB 트랜잭션이 최종 커밋된 후 Redis의 안 읽은 메시지 수를 업데이트하기 위해 사용됨.
+ */
+@Getter
+@RequiredArgsConstructor
+public class MessageCreatedEvent {
+    private final Long roomId;
+    private final Long receiverId;
+}

--- a/backend/src/main/java/com/example/readys7project/domain/chat/message/event/UnreadCountEventHandler.java
+++ b/backend/src/main/java/com/example/readys7project/domain/chat/message/event/UnreadCountEventHandler.java
@@ -1,0 +1,37 @@
+package com.example.readys7project.domain.chat.message.event;
+
+import com.example.readys7project.domain.chat.message.service.UnreadCountService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 메시지 생성 이벤트 핸들러
+ * DB 트랜잭션이 최종 커밋된 후(AFTER_COMMIT) Redis의 unread count를 업데이트함.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UnreadCountEventHandler {
+
+    private final UnreadCountService unreadCountService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMessageCreated(MessageCreatedEvent event) {
+        try {
+            log.info("DB 커밋 감지: Redis unread count 업데이트 (Room: {}, Receiver: {})", 
+                    event.getRoomId(), event.getReceiverId());
+            
+            unreadCountService.increment(event.getRoomId(), event.getReceiverId());
+            
+        } catch (Exception e) {
+            log.error("Redis unread count 업데이트 중 에러 발생 (Room: {}, User: {}): {}", 
+                    event.getRoomId(), event.getReceiverId(), e.getMessage());
+            // 필요 시 재시도 로직이나 후속 처리 추가 가능
+        }
+    }
+}

--- a/backend/src/main/java/com/example/readys7project/domain/chat/message/service/MessageService.java
+++ b/backend/src/main/java/com/example/readys7project/domain/chat/message/service/MessageService.java
@@ -6,6 +6,7 @@ import com.example.readys7project.domain.chat.message.enums.MessageEventType;
 import com.example.readys7project.domain.chat.message.dto.request.SendMessageRequestDto;
 import com.example.readys7project.domain.chat.message.dto.response.MessageCursorResponseDto;
 import com.example.readys7project.domain.chat.message.dto.response.MessageResponseDto;
+import com.example.readys7project.domain.chat.message.event.MessageCreatedEvent;
 import com.example.readys7project.domain.chat.message.entity.Message;
 import com.example.readys7project.domain.chat.message.repository.MessageRepository;
 import com.example.readys7project.domain.user.auth.entity.User;
@@ -13,6 +14,7 @@ import com.example.readys7project.domain.user.auth.repository.UserRepository;
 import com.example.readys7project.global.exception.common.ErrorCode;
 import com.example.readys7project.global.exception.domain.MessageException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +29,7 @@ public class MessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
     private final UnreadCountService unreadCountService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public MessageResponseDto saveMessage(Long roomId, SendMessageRequestDto request, String email) {
@@ -49,12 +52,13 @@ public class MessageService {
 
         Message savedMessage = messageRepository.save(message);
 
-        // 상대방 unread count 증가
+        // 상대방 unread count 증가 (이벤트 발행으로 전환)
         Long receiverId = chatRoom.getClient().getUser().getId().equals(user.getId())
                 ? chatRoom.getDeveloper().getUser().getId()  // 보낸 사람이 client면 developer가 수신자
                 : chatRoom.getClient().getUser().getId();    // 보낸 사람이 developer면 client가 수신자
 
-        unreadCountService.increment(roomId, receiverId);
+        // 직접 호출 대신 이벤트 발행
+        eventPublisher.publishEvent(new MessageCreatedEvent(roomId, receiverId));
 
         return convertToDto(savedMessage, MessageEventType.SEND);
     }

--- a/backend/src/main/java/com/example/readys7project/domain/proposal/entity/Proposal.java
+++ b/backend/src/main/java/com/example/readys7project/domain/proposal/entity/Proposal.java
@@ -14,7 +14,9 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
-@Table(name = "proposals")
+@Table(name = "proposals", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"project_id", "developer_id"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE proposals SET is_deleted = true WHERE id = ?") // 삭제 시 실행될 SQL 커스텀
 @SQLRestriction("is_deleted = false")

--- a/backend/src/main/java/com/example/readys7project/global/exception/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/readys7project/global/exception/common/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -21,6 +22,17 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    // 409 - 데이터 무결성 위반 (중복 데이터 등)
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponseDto.error(
+                        "DATA_INTEGRITY_VIOLATION",
+                        "이미 존재하는 데이터이거나 데이터 제약 조건을 위반했습니다."
+                ));
+    }
 
     // 도메인 커스텀 예외
     @ExceptionHandler(ServiceException.class)

--- a/backend/src/main/java/com/example/readys7project/global/security/StompAuthInterceptor.java
+++ b/backend/src/main/java/com/example/readys7project/global/security/StompAuthInterceptor.java
@@ -1,6 +1,11 @@
 package com.example.readys7project.global.security;
 
+import com.example.readys7project.domain.chat.chatroom.entity.ChatRoom;
+import com.example.readys7project.domain.chat.chatroom.repository.ChatRoomRepository;
+import com.example.readys7project.domain.chat.cs.entity.CsChatRoom;
+import com.example.readys7project.domain.chat.cs.repository.CsChatRoomRepository;
 import com.example.readys7project.domain.user.auth.entity.User;
+import com.example.readys7project.domain.user.auth.enums.UserRole;
 import com.example.readys7project.domain.user.auth.repository.UserRepository;
 import com.example.readys7project.global.exception.common.ErrorCode;
 import com.example.readys7project.global.exception.domain.MessageException;
@@ -24,6 +29,8 @@ public class StompAuthInterceptor implements ChannelInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final CsChatRoomRepository csChatRoomRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -31,7 +38,13 @@ public class StompAuthInterceptor implements ChannelInterceptor {
                 message, StompHeaderAccessor.class
         );
 
-        if (StompCommand.CONNECT.equals(Objects.requireNonNull(accessor).getCommand())) {
+        if (accessor == null) {
+            return message;
+        }
+
+        StompCommand command = accessor.getCommand();
+
+        if (StompCommand.CONNECT.equals(command)) {
             String token = accessor.getFirstNativeHeader("Authorization");
 
             if (token != null && token.startsWith("Bearer ")) {
@@ -50,17 +63,80 @@ public class StompAuthInterceptor implements ChannelInterceptor {
 
                 accessor.setUser(authentication);
             }
+        } else if (StompCommand.SUBSCRIBE.equals(command)) {
+            String destination = accessor.getDestination();
+            if (destination != null) {
+                // 일반 채팅방 권한 검증
+                if (destination.startsWith("/receive/chat/rooms/")) {
+                    validateChatRoomSubscription(accessor, destination);
+                }
+                // CS 채팅방 권한 검증
+                else if (destination.startsWith("/receive/chat/cs/")) {
+                    validateCsChatRoomSubscription(accessor, destination);
+                }
+            }
         }
 
         // 비정상 종료 처리
-        if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+        if (StompCommand.DISCONNECT.equals(command)) {
             // Principal이 있을 때만 처리 (정상 연결 후 끊긴 경우)
             if (accessor.getUser() != null) {
                 log.warn("STOMP DISCONNECT 감지: {}", accessor.getUser().getName());
-                // 필요 시 추가 처리 (예: 접속 상태 관리)
             }
         }
 
         return message;
+    }
+
+    private void validateChatRoomSubscription(StompHeaderAccessor accessor, String destination) {
+        Long roomId = extractRoomId(destination, "/receive/chat/rooms/");
+        UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) accessor.getUser();
+
+        if (auth == null) {
+            throw new MessageException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
+        User user = userDetails.getUser();
+
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new MessageException(ErrorCode.CHATROOM_NOT_FOUND));
+
+        boolean isClient = chatRoom.getClient().getUser().getId().equals(user.getId());
+        boolean isDeveloper = chatRoom.getDeveloper().getUser().getId().equals(user.getId());
+
+        if (!isClient && !isDeveloper) {
+            throw new MessageException(ErrorCode.USER_FORBIDDEN);
+        }
+    }
+
+    private void validateCsChatRoomSubscription(StompHeaderAccessor accessor, String destination) {
+        Long roomId = extractRoomId(destination, "/receive/chat/cs/");
+        UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) accessor.getUser();
+
+        if (auth == null) {
+            throw new MessageException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
+        User user = userDetails.getUser();
+
+        CsChatRoom room = csChatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new MessageException(ErrorCode.CHATROOM_NOT_FOUND));
+
+        boolean isInquirer = room.getInquirer().getId().equals(user.getId());
+        boolean isAdmin = user.getUserRole() == UserRole.ADMIN;
+
+        if (!isInquirer && !isAdmin) {
+            throw new MessageException(ErrorCode.USER_FORBIDDEN);
+        }
+    }
+
+    private Long extractRoomId(String destination, String prefix) {
+        try {
+            return Long.parseLong(destination.substring(prefix.length()));
+        } catch (NumberFormatException | StringIndexOutOfBoundsException e) {
+            throw new MessageException(ErrorCode.INVALID_INPUT);
+        }
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -32,7 +32,7 @@ jwt:
   refresh-token-validity-in-seconds: ${JWT_REFRESH_EXPIRATION:604800}
 
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173}
   allowed-methods: GET,POST,PUT,DELETE,PATCH,OPTIONS
   allowed-headers: "*"
   exposed-headers: Authorization


### PR DESCRIPTION
## 개요
- 채팅방 구독 검증 추가, 제안서 제출 시 멱등성, 채팅 unreadcount에서 DB-Redis 간 데이터 불일치

## 변경 사항
- 채팅방 구독 검증 추가
	- CONNECT 시점에만 JWT 인증을 수행하며, 특정 roomId에 대한 SUBSCRIBE 권한을 체크하지 않는 부분 해결
- 제안서 제출 시 멱등성
	- '조회 후 저장' 방식의 비원자적 로직으로 인해 동시 요청 시 중복 제안서 생성 가능한 부분 해결
- 채팅 unreadcount에서 DB-Redis 간 데이터 불일치
	- transaction 과정에서 실패하면 DB 롤백 시 Redis 데이터만 업데이트된 상태로 남는 부분 해결

## 관련 이슈
- 이 PR과 관련된 이슈 번호를 작성해주세요. (e.g., `#123`)
  - Resolves #108 
